### PR TITLE
Update `data-integrity-test-suite-assertion` package to use `main` branch.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "canonicalize": "^1.0.8",
     "chai": "^4.3.6",
     "credentials-context": "^2.0.0",
-    "data-integrity-test-suite-assertion": "github:w3c-ccg/data-integrity-test-suite-assertion#use-endpoint-class",
+    "data-integrity-test-suite-assertion": "github:w3c-ccg/data-integrity-test-suite-assertion",
     "jsonld-document-loader": "^1.2.1",
     "klona": "^2.0.5",
     "mocha": "^10.0.0",

--- a/tests/10-create.js
+++ b/tests/10-create.js
@@ -37,91 +37,93 @@ describe('eddsa-2022 (create)', function() {
     this.rowLabel = 'Test Name';
     this.columnLabel = 'Implementation';
     for(const [columnId, {endpoints, implementation}] of match) {
-      const [issuer] = endpoints;
-      const verifier = implementation.verifiers.find(
-        v => v.tags.has(tag));
-      let issuedVc;
-      let proofs;
-      before(async function() {
-        issuedVc = await createInitialVc({issuer, vc: validVc});
-        proofs = Array.isArray(issuedVc?.proof) ?
-          issuedVc.proof : [issuedVc?.proof];
-      });
-      it('MUST have property "cryptosuite"', function() {
-        this.test.cell = {columnId, rowId: this.test.title};
-        proofs.some(
-          proof => typeof proof?.cryptosuite === 'string'
-        ).should.equal(
-          true,
-          'Expected at least one proof to have cryptosuite.'
-        );
-      });
-      it('The field "cryptosuite" MUST be `eddsa-2022`', function() {
-        this.test.cell = {columnId, rowId: this.test.title};
-        proofs.some(
-          proof => proof?.cryptosuite === cryptosuite
-        ).should.equal(
-          true,
-          'Expected at least one proof to have "cryptosuite" `eddsa-2022`.'
-        );
-      });
-      it('"proofValue" field MUST exist and be a multibase-encoded ' +
-          'base58-btc encoded value', function() {
-        this.test.cell = {columnId, rowId: this.test.title};
-        const multibase = 'z';
-        proofs.some(proof => {
-          const value = proof?.proofValue || '';
-          return value.startsWith(multibase) && shouldBeBs58(value);
-        }).should.equal(
-          true,
-          'Expected "proof.proofValue" to be multibase-encoded base58-btc ' +
-          'value.'
-        );
-      });
-      it('"proofValue" field when decoded to raw bytes, MUST be 64 bytes ' +
-        'in length if the associated public key is 32 bytes or 114 bytes ' +
-        'in length if the public key is 57 bytes.', async function() {
-        this.test.cell = {columnId, rowId: this.test.title};
-        should.exist(issuedVc, 'Expected issuer to have issued a ' +
-          'credential.');
-        should.exist(proofs, 'Expected credential to have a proof.');
-        const eddsa2022Proofs = proofs.filter(
-          proof => proof?.cryptosuite === cryptosuite);
-        eddsa2022Proofs.length.should.be.gte(1, 'Expected at least one ' +
-          'eddsa-2022 cryptosuite.');
-        for(const proof of eddsa2022Proofs) {
-          should.exist(proof.proofValue, 'Expected a proof value on ' +
-            'the proof.');
-          const valueBytes = bs58Decode({id: proof.proofValue});
-          should.exist(proof.verificationMethod);
-          const vmBytes = await getPublicKeyBytes({
-            did: proof.verificationMethod});
-          vmBytes.byteLength.should.be.oneOf([32, 57], 'Expected public ' +
-            'key bytes to be either 32 or 57 bytes.');
-          if(vmBytes.byteLength === 32) {
-            valueBytes.byteLength.should.equal(64, 'Expected 64 bytes ' +
-              'proofValue for 32 bytes key.');
-          } else {
-            valueBytes.byteLength.should.equal(114, 'Expected 114 bytes ' +
-              'proofValue for 57 bytes key.');
-          }
-        }
-      });
-      it('"proof" MUST verify when using a conformant verifier.',
-        async function() {
-          this.test.cell = {columnId, rowId: this.test.title};
-          should.exist(verifier, 'Expected implementation to have a VC ' +
-            'HTTP API compatible verifier.');
-          const {result, error} = await verifier.post({json: {
-            verifiableCredential: issuedVc,
-            options: {checks: ['proof']}
-          }});
-          should.not.exist(error, 'Expected verifier to not error.');
-          should.exist(result, 'Expected verifier to return a result.');
-          result.status.should.not.equal(400, 'Expected status code to not ' +
-            'be 400.');
-          result.status.should.equal(200, 'Expected status code to be 200.');
+      describe(columnId, function() {
+        const [issuer] = endpoints;
+        const verifier = implementation.verifiers.find(
+          v => v.tags.has(tag));
+        let issuedVc;
+        let proofs;
+        before(async function() {
+          issuedVc = await createInitialVc({issuer, vc: validVc});
+          proofs = Array.isArray(issuedVc?.proof) ?
+            issuedVc.proof : [issuedVc?.proof];
         });
+        it('MUST have property "cryptosuite"', function() {
+          this.test.cell = {columnId, rowId: this.test.title};
+          proofs.some(
+            proof => typeof proof?.cryptosuite === 'string'
+          ).should.equal(
+            true,
+            'Expected at least one proof to have cryptosuite.'
+          );
+        });
+        it('The field "cryptosuite" MUST be `eddsa-2022`', function() {
+          this.test.cell = {columnId, rowId: this.test.title};
+          proofs.some(
+            proof => proof?.cryptosuite === cryptosuite
+          ).should.equal(
+            true,
+            'Expected at least one proof to have "cryptosuite" `eddsa-2022`.'
+          );
+        });
+        it('"proofValue" field MUST exist and be a multibase-encoded ' +
+            'base58-btc encoded value', function() {
+          this.test.cell = {columnId, rowId: this.test.title};
+          const multibase = 'z';
+          proofs.some(proof => {
+            const value = proof?.proofValue || '';
+            return value.startsWith(multibase) && shouldBeBs58(value);
+          }).should.equal(
+            true,
+            'Expected "proof.proofValue" to be multibase-encoded base58-btc ' +
+            'value.'
+          );
+        });
+        it('"proofValue" field when decoded to raw bytes, MUST be 64 bytes ' +
+          'in length if the associated public key is 32 bytes or 114 bytes ' +
+          'in length if the public key is 57 bytes.', async function() {
+          this.test.cell = {columnId, rowId: this.test.title};
+          should.exist(issuedVc, 'Expected issuer to have issued a ' +
+            'credential.');
+          should.exist(proofs, 'Expected credential to have a proof.');
+          const eddsa2022Proofs = proofs.filter(
+            proof => proof?.cryptosuite === cryptosuite);
+          eddsa2022Proofs.length.should.be.gte(1, 'Expected at least one ' +
+            'eddsa-2022 cryptosuite.');
+          for(const proof of eddsa2022Proofs) {
+            should.exist(proof.proofValue, 'Expected a proof value on ' +
+              'the proof.');
+            const valueBytes = bs58Decode({id: proof.proofValue});
+            should.exist(proof.verificationMethod);
+            const vmBytes = await getPublicKeyBytes({
+              did: proof.verificationMethod});
+            vmBytes.byteLength.should.be.oneOf([32, 57], 'Expected public ' +
+              'key bytes to be either 32 or 57 bytes.');
+            if(vmBytes.byteLength === 32) {
+              valueBytes.byteLength.should.equal(64, 'Expected 64 bytes ' +
+                'proofValue for 32 bytes key.');
+            } else {
+              valueBytes.byteLength.should.equal(114, 'Expected 114 bytes ' +
+                'proofValue for 57 bytes key.');
+            }
+          }
+        });
+        it('"proof" MUST verify when using a conformant verifier.',
+          async function() {
+            this.test.cell = {columnId, rowId: this.test.title};
+            should.exist(verifier, 'Expected implementation to have a VC ' +
+              'HTTP API compatible verifier.');
+            const {result, error} = await verifier.post({json: {
+              verifiableCredential: issuedVc,
+              options: {checks: ['proof']}
+            }});
+            should.not.exist(error, 'Expected verifier to not error.');
+            should.exist(result, 'Expected verifier to return a result.');
+            result.status.should.not.equal(400, 'Expected status code to not ' +
+              'be 400.');
+            result.status.should.equal(200, 'Expected status code to be 200.');
+          });
+      });
     }
   });
 });


### PR DESCRIPTION
- Moved issuer tests inside a `describe` block with implementation name as it's description to separate out the tests for the different implementations.
- Update `data-integrity-test-suite-assertion` to use main branch. `#use-endpoint-class` branch no longer exists.